### PR TITLE
Corrige la non prise en charge des messages excédant 1024 caractères dans les logs

### DIFF
--- a/mp2i/cogs/events.py
+++ b/mp2i/cogs/events.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from math import ceil
 
 import discord
 from discord.ext.commands import Cog
@@ -110,8 +111,10 @@ class EventsCog(Cog):
         if msg.channel == guild.admin_channel or msg.author.bot:
             return
 
-        nb_parts = int(len(msg.content) / MAX_MESSAGE_LENGTH) + 1
+        nb_parts = ceil(len(msg.content) / MAX_MESSAGE_LENGTH)
         for part in range(0, nb_parts):
+            begin = part * MAX_MESSAGE_LENGTH
+            message_content = msg.content[begin : begin + MAX_MESSAGE_LENGTH]
             embed = discord.Embed(
                 title="Message supprimé",
                 colour=0xED0010,
@@ -126,7 +129,7 @@ class EventsCog(Cog):
                 )
             embed.add_field(
                 name="Message original",
-                value=f">>> {msg.content[part * MAX_MESSAGE_LENGTH:(part + 1) * MAX_MESSAGE_LENGTH]}",
+                value=f">>> {message_content}",
                 inline=False
             )
             embed.set_footer(text=self.bot.user.name)
@@ -144,8 +147,10 @@ class EventsCog(Cog):
         if before.channel == guild.admin_channel or before.author.bot:
             return
 
-        nb_parts = int(len(before.content) / MAX_MESSAGE_LENGTH) + 1
+        nb_parts = ceil(len(before.content) / MAX_MESSAGE_LENGTH)
         for part in range(0, nb_parts):
+            begin = part * MAX_MESSAGE_LENGTH
+            message_content = before.content[begin: begin + MAX_MESSAGE_LENGTH]
             embed = discord.Embed(
                 title="Message modifié",
                 colour=0x6DD7FF,
@@ -163,7 +168,7 @@ class EventsCog(Cog):
                 )
             embed.add_field(
                 name="Message original",
-                value=f">>> {before.content[part * MAX_MESSAGE_LENGTH:(part + 1) * MAX_MESSAGE_LENGTH]}",
+                value=f">>> {message_content}",
                 inline=False
             )
             embed.set_footer(text=self.bot.user.name)

--- a/mp2i/cogs/events.py
+++ b/mp2i/cogs/events.py
@@ -12,6 +12,7 @@ from mp2i.wrappers.guild import GuildWrapper
 
 logger = logging.getLogger(__name__)
 
+MAX_MESSAGE_LENGTH = 1020 # Can not exceed 1024
 
 class EventsCog(Cog):
     def __init__(self, bot):
@@ -109,18 +110,27 @@ class EventsCog(Cog):
         if msg.channel == guild.admin_channel or msg.author.bot:
             return
 
-        embed = discord.Embed(
-            title="Message supprimé",
-            colour=0xED0010,
-            timestamp=datetime.now(),
-        )
-        embed.add_field(name="Auteur", value=msg.author.mention)
-        embed.add_field(name="Salon", value=msg.channel.mention)
-        embed.add_field(
-            name="Message original", value=f">>> {msg.content}", inline=False
-        )
-        embed.set_footer(text=self.bot.user.name)
-        await guild.log_channel.send(embed=embed)
+        nb_parts = int(len(msg.content) / MAX_MESSAGE_LENGTH) + 1
+        for part in range(0, nb_parts):
+            embed = discord.Embed(
+                title="Message supprimé",
+                colour=0xED0010,
+                timestamp=datetime.now(),
+            )
+            embed.add_field(name="Auteur", value=msg.author.mention)
+            embed.add_field(name="Salon", value=msg.channel.mention)
+            if nb_parts > 1:
+                embed.add_field(
+                    name="Partie",
+                    value=f"{part + 1}/{nb_parts}"
+                )
+            embed.add_field(
+                name="Message original",
+                value=f">>> {msg.content[part * MAX_MESSAGE_LENGTH:(part + 1) * MAX_MESSAGE_LENGTH]}",
+                inline=False
+            )
+            embed.set_footer(text=self.bot.user.name)
+            await guild.log_channel.send(embed=embed)
 
     @Cog.listener()
     async def on_message_edit(self, before, after) -> None:
@@ -134,18 +144,30 @@ class EventsCog(Cog):
         if before.channel == guild.admin_channel or before.author.bot:
             return
 
-        embed = discord.Embed(
-            title="Message modifié",
-            colour=0x6DD7FF,
-            timestamp=datetime.now(),
-        )
-        embed.add_field(name="Auteur", value=before.author.mention)
-        embed.add_field(name="Lien du nouveau message", value=after.jump_url)
-        embed.add_field(
-            name="Message original", value=f">>> {before.content}", inline=False
-        )
-        embed.set_footer(text=self.bot.user.name)
-        await log_chan.send(embed=embed)
+        nb_parts = int(len(before.content) / MAX_MESSAGE_LENGTH) + 1
+        for part in range(0, nb_parts):
+            embed = discord.Embed(
+                title="Message modifié",
+                colour=0x6DD7FF,
+                timestamp=datetime.now(),
+            )
+            embed.add_field(name="Auteur", value=before.author.mention)
+            embed.add_field(
+                name="Lien du nouveau message",
+                value=after.jump_url
+            )
+            if nb_parts > 1:
+                embed.add_field(
+                    name="Partie",
+                    value=f"{part + 1}/{nb_parts}"
+                )
+            embed.add_field(
+                name="Message original",
+                value=f">>> {before.content[part * MAX_MESSAGE_LENGTH:(part + 1) * MAX_MESSAGE_LENGTH]}",
+                inline=False
+            )
+            embed.set_footer(text=self.bot.user.name)
+            await log_chan.send(embed=embed)
 
 
 async def setup(bot) -> None:


### PR DESCRIPTION
L'API de Discord demande des champs inférieur à 1024 caractères pour les embeds. Cette PR propose de découper le message à log en plusieurs embeds si nécessaire.
