### PR TITLE
Ajout de l'interaction "Profil" dans le menu contextuel d'un utilisateur

### DIFF
--- a/mp2i/cogs/commands.py
+++ b/mp2i/cogs/commands.py
@@ -155,6 +155,7 @@ class Commands(Cog):
 
         await ctx.send(embed=embed)
 
+    @defer(ephemeral=True)
     async def get_profile(self, interaction: discord.Interaction, member: discord.Member):
         """
         Consulte les infos d'un membre.
@@ -166,7 +167,6 @@ class Commands(Cog):
         member : discord.Member
             Membre à consulter.
         """
-        await interaction.response.defer(ephemeral=True)
         await self.generate_profile(interaction.followup, interaction.user, member)
 
     @hybrid_command(name="profile")

--- a/mp2i/cogs/commands.py
+++ b/mp2i/cogs/commands.py
@@ -4,6 +4,7 @@ from typing import Optional
 from operator import attrgetter
 
 import discord
+from discord import app_commands, AppCommandType
 from discord.ext.commands import Cog, Range
 from discord.ext.commands import (
     hybrid_command,
@@ -26,6 +27,13 @@ LEADERBOARD_RANK_MAX = 50
 class Commands(Cog):
     def __init__(self, bot):
         self.bot = bot
+        ctx_menu = app_commands.ContextMenu(
+            name='Profil',
+            callback=self.get_profile,
+            type=AppCommandType.user
+        )
+        ctx_menu.guild_only = True
+        self.bot.tree.add_command(ctx_menu)
 
     @Cog.listener("on_ready")
     async def set_default_status(self) -> None:
@@ -111,19 +119,18 @@ class Commands(Cog):
             await ctx.reply(f"Message envoyé dans {channel.mention}.", ephemeral=True)
         await channel.send(message)
 
-    @hybrid_command(name="profile")
-    @guild_only()
-    @defer()
-    async def profile(self, ctx, member: Optional[discord.Member] = None) -> None:
+    async def generate_profile(self, ctx, user: discord.Member, member: Optional[discord.Member] = None, ephemeral: bool = False) -> None:
         """
         Consulte les infos d'un membre.
 
         Parameters
         ----------
+        user: discord.Member
+            Membre qui exécute la commande.
         member : discord.Member
             Membre à consulter.
         """
-        member = MemberWrapper(member or ctx.author)
+        member = MemberWrapper(member or user)
         embed = discord.Embed(title="Profil", colour=int(member.profile_color, 16))
         embed.set_author(name=member.name)
         if member.avatar is None:
@@ -144,7 +151,35 @@ class Commands(Cog):
         if member.engineering_school is not None:
             embed.add_field(name="École d'ingénieur", value=member.engineering_school)
 
-        await ctx.send(embed=embed)
+        await ctx.send(embed=embed, ephemeral=ephemeral)
+
+    async def get_profile(self, interaction: discord.Interaction, member: discord.Member):
+        """
+        Consulte les infos d'un membre.
+
+        Parameters
+        ----------
+        interaction : discord.Interaction
+            Interaction du contexte.
+        member : discord.Member
+            Membre à consulter.
+        """
+        await interaction.response.defer()
+        await self.generate_profile(interaction.followup, interaction.user, member, True)
+
+    @hybrid_command(name="profile")
+    @guild_only()
+    @defer()
+    async def profile(self, ctx, member: Optional[discord.Member] = None) -> None:
+        """
+        Consulte les infos d'un membre.
+
+        Parameters
+        ----------
+        member : discord.Member
+            Membre à consulter.
+        """
+        await self.generate_profile(ctx, ctx.author, member)
 
     @hybrid_command(name="profilecolor")
     @guild_only()

--- a/mp2i/cogs/commands.py
+++ b/mp2i/cogs/commands.py
@@ -119,16 +119,18 @@ class Commands(Cog):
             await ctx.reply(f"Message envoyé dans {channel.mention}.", ephemeral=True)
         await channel.send(message)
 
-    async def generate_profile(self, ctx, user: discord.Member, member: Optional[discord.Member] = None, ephemeral: bool = False) -> None:
+    async def generate_profile(self, ctx, user: discord.Member, member: Optional[discord.Member] = None) -> None:
         """
         Consulte les infos d'un membre.
 
         Parameters
         ----------
-        user: discord.Member
+        user : discord.Member
             Membre qui exécute la commande.
         member : discord.Member
             Membre à consulter.
+        ephemeral : bool
+            Message personnel.
         """
         member = MemberWrapper(member or user)
         embed = discord.Embed(title="Profil", colour=int(member.profile_color, 16))
@@ -151,7 +153,7 @@ class Commands(Cog):
         if member.engineering_school is not None:
             embed.add_field(name="École d'ingénieur", value=member.engineering_school)
 
-        await ctx.send(embed=embed, ephemeral=ephemeral)
+        await ctx.send(embed=embed)
 
     async def get_profile(self, interaction: discord.Interaction, member: discord.Member):
         """
@@ -164,8 +166,8 @@ class Commands(Cog):
         member : discord.Member
             Membre à consulter.
         """
-        await interaction.response.defer()
-        await self.generate_profile(interaction.followup, interaction.user, member, True)
+        await interaction.response.defer(ephemeral=True)
+        await self.generate_profile(interaction.followup, interaction.user, member)
 
     @hybrid_command(name="profile")
     @guild_only()

--- a/mp2i/cogs/commands.py
+++ b/mp2i/cogs/commands.py
@@ -144,7 +144,7 @@ class Commands(Cog):
         embed.add_field(name="Messages", value=member.messages_count)
         embed.add_field(
             name="Rôles",
-            value=" ".join(r.mention for r in member.roles if r.name != "@everyone"),
+            value=" ".join(r.mention for r in reversed(member.roles) if r.name != "@everyone"),
         )
         if member.high_school:
             embed.add_field(name="CPGE", value=member.high_school)

--- a/mp2i/utils/discord.py
+++ b/mp2i/utils/discord.py
@@ -1,6 +1,7 @@
 import logging
 from functools import wraps
 
+import discord
 from discord.ext.commands.errors import NoPrivateMessage, MissingAnyRole
 from discord.ext.commands import check
 
@@ -17,7 +18,10 @@ def defer(ephemeral: bool = False):
     def decorator(func):
         @wraps(func)
         async def command_wrapper(self, ctx, *args, **kwargs):
-            await ctx.defer(ephemeral=ephemeral)
+            if type(ctx) is discord.Interaction:
+                await ctx.response.defer(ephemeral=ephemeral)
+            else:
+                await ctx.defer(ephemeral=ephemeral)
             await func(self, ctx, *args, **kwargs)
 
         return command_wrapper


### PR DESCRIPTION
La PR propose l'ajout d'une interaction dans le menu contextuel d'un utilisateur pour obtenir son profil sans avoir à faire une commande. La réponse à cette interaction est le même embed que celui de la commande mais envoyé de façon éphémère.