### PR TITLE
Suppression l'erreur 'AttributeError' lors de la MàJ d'un membre

### DIFF
--- a/mp2i/cogs/sanctions.py
+++ b/mp2i/cogs/sanctions.py
@@ -400,12 +400,16 @@ class Sanction(Cog):
 
         # Doit être étrangement avant la condition de TO sinon ne s'applique pas
         elif entry.action == AuditLogAction.member_update and (
+            hasattr(entry.before, "timed_out_until") and
+            hasattr(entry.after, "timed_out_until") and
             entry.before.timed_out_until and not entry.after.timed_out_until
         ):
             insert_in_database("unto", None)
             await handle_log_unto(user, staff)
 
         elif entry.action == AuditLogAction.member_update and (
+            hasattr(entry.before, "timed_out_until") and
+            hasattr(entry.after, "timed_out_until") and
             not entry.before.timed_out_until
             and entry.after.timed_out_until
             or entry.before.timed_out_until


### PR DESCRIPTION
Vérification de la présence de l'attribut utilisé. Voir [ce message](https://discord.com/channels/336642139381301249/1285712906872291349/1285712906872291349) sur le discord de Discord.Py.