### PR TITLE
Amélioration du leaderboard

### DIFF
--- a/mp2i/cogs/commands.py
+++ b/mp2i/cogs/commands.py
@@ -1,7 +1,6 @@
 import re
 import logging
 from typing import Optional
-from operator import attrgetter
 
 import discord
 from discord import app_commands, AppCommandType
@@ -19,8 +18,6 @@ from mp2i.wrappers.member import MemberWrapper
 from mp2i.utils.discord import defer, has_any_role
 
 logger = logging.getLogger(__name__)
-
-LEADERBOARD_RANK_MAX = 50
 
 
 class Commands(Cog):
@@ -186,40 +183,6 @@ class Commands(Cog):
                 number = len(guild.get_role(role_cfg.id).members)
                 emoji = guild.get_emoji_by_name(role_cfg.emoji)
                 embed.add_field(name=f"{emoji} {role_name}", value=number)
-        await ctx.send(embed=embed)
-
-    @hybrid_command(name="leaderboard")
-    @guild_only()
-    @defer()
-    async def leaderboard(self, ctx, rmax: Optional[int] = 10) -> None:
-        """
-        Affiche le classement des membres par nombre de messages.
-
-        Parameters
-        ----------
-        rmax : int
-            Rang maximal (compris entre 0 et 50)
-        """
-        if rmax < 0 or rmax > LEADERBOARD_RANK_MAX:
-            message = f"rmax doit être compris entre 0 et {LEADERBOARD_RANK_MAX}"
-            return await ctx.reply(message, ephemeral=True)
-
-        members = [MemberWrapper(m) for m in ctx.guild.members if not m.bot]
-        members.sort(key=attrgetter("messages_count"), reverse=True)
-
-        author = MemberWrapper(ctx.author)
-        rank = members.index(author) + 1
-        content = f"→ {rank}. **{author.name}** : {author.messages_count} messages\n\n"
-
-        if rmax == 0:
-            title = "Votre classement dans le serveur :"
-        else:
-            title = f"Top {rmax} des membres du serveur"
-
-        for r, member in enumerate(members[:rmax], 1):
-            content += f"{r}. **{member.name}** : {member.messages_count} messages\n"
-
-        embed = discord.Embed(colour=0x2BFAFA, title=title, description=content)
         await ctx.send(embed=embed)
 
 async def setup(bot) -> None:

--- a/mp2i/cogs/leaderboard.py
+++ b/mp2i/cogs/leaderboard.py
@@ -1,0 +1,80 @@
+from typing import List
+from operator import attrgetter
+import re
+
+from discord.ext.commands import Cog
+from discord.ext.commands import (
+    hybrid_command,
+    guild_only,
+)
+
+from mp2i.wrappers.member import MemberWrapper
+from mp2i.utils.discord import defer, EmbedPaginator
+
+NAME_REGEX: re.Pattern = re.compile(r"([^\|@]+)(@|\||#):?[^@#\|]*")
+
+
+class Leaderboard(Cog):
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @hybrid_command(name="leaderboard")
+    @guild_only()
+    @defer()
+    async def leaderboard(self, ctx) -> None:
+        """
+        Affiche le classement des membres par nombre de messages.
+        """
+
+        members: List[MemberWrapper] = [MemberWrapper(m) for m in ctx.guild.members if not m.bot]
+        members.sort(key=attrgetter("messages_count"), reverse=True)
+        
+        author: MemberWrapper = MemberWrapper(ctx.author)
+        rank: int = members.index(author) + 1
+        # get author display name without school
+        user_name: str = author.display_name
+        if m := NAME_REGEX.match(user_name):
+            user_name = m.group(1).strip()
+        header: str = f"→ {rank}. **{user_name}** : {author.messages_count} messages\n\n"
+        content: List[str] = []
+
+        title = f"Top des membres du serveur"
+
+        # retrieve each line
+        for r, member in enumerate(members, 1):
+            user_name: str = member.display_name
+            if m := NAME_REGEX.match(user_name):
+                user_name = m.group(1).strip()
+            content.append(f"{r}. **{user_name}** : {member.messages_count} messages\n")
+
+        # select colour of first's profil
+        colour = int(members[0].profile_color, 16)
+
+        # if first's profil has default colour get
+        # their first coloured role's colour
+        if colour == 0x0000FF:
+            colour = members[0].member.roles[0].colour
+            # reverse to get the top role
+            for role in reversed(members[0].member.roles):
+                # discriminate role by its string colour
+                if f"{role.colour}" != "#000000":
+                    colour = role.colour
+                    break
+
+        # create paginate embed
+        embed = EmbedPaginator(
+            title=title,
+            colour=colour,
+            content_header=header,
+            content_body=content,
+            nb_by_pages=10,
+            footer="",
+            author_id=ctx.author.id,
+            timeout=500,
+        )
+
+        await embed.send(ctx)
+
+async def setup(bot) -> None:
+    await bot.add_cog(Leaderboard(bot))

--- a/mp2i/cogs/leaderboard.py
+++ b/mp2i/cogs/leaderboard.py
@@ -54,7 +54,6 @@ class Leaderboard(Cog):
         # if first's profil has default colour get
         # their first coloured role's colour
         if colour == 0x0000FF:
-            colour = members[0].member.roles[0].colour
             # reverse to get the top role
             for role in reversed(members[0].member.roles):
                 # discriminate role by its string colour

--- a/mp2i/utils/discord.py
+++ b/mp2i/utils/discord.py
@@ -1,6 +1,6 @@
 import logging
 from functools import wraps
-from typing import List
+from typing import List, Optional
 from datetime import datetime
 
 import discord
@@ -60,7 +60,7 @@ class EmbedPaginator(discord.ui.View):
     Class to create an embed paginator.
     """
 
-    def __init__(self, title: str, colour: discord.Colour, content_header: str, content_body: List[str], nb_by_pages: int, footer: str, author_id: int, timestamp: datetime = None, timeout: int = 60):
+    def __init__(self, title: str, colour: discord.Colour, content_header: str, content_body: List[str], nb_by_pages: int, footer: str, author_id: int, timestamp: Optional[datetime] = None, timeout: int = 60):
         super().__init__(timeout=timeout)
 
         if timestamp is None:


### PR DESCRIPTION
Cette PR propose l'ajout de la pagination au leaderboard. Elle ajoute également l'utilisation des noms personnalisés à la place des noms utilisateurs. Par ailleurs, la couleur de l'embed prend la couleur du profil du TOP 1 du serveur, si elle est différente de la couleur par défaut. Dans le cas contraire, la couleur du rôle le plus haut est choisie si ce-dernier en possède une. 